### PR TITLE
fix: Dockerfile errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,26 +3,31 @@ ARG NODE_VERSION=node:current-alpine3.17
 ARG ENV=production
 
 # Stage 1: Build the project
-FROM NODE_VERSION AS builder
+#Put the variable in ${}
+FROM ${NODE_VERSION} AS builder
 
 # Set the working directory
 WORKDIR /app
 
 # Copy All
-COPY . 
+# Copy all from the current directory to the working directory in the image
+COPY . .
 
 # Install project dependencies and build the project
-RUN npm ci \
-    npm run build \
+#Added &&
+RUN npm ci && \
+    npm run build &&  \
     ls
 
 # Stage 2: Create a minimal production image
-FROM NODE_VERSION AS deploy
+#Put the variable in ${}
+FROM ${NODE_VERSION} AS deploy
 
 # Set the working directory
 WORKDIR /app
 
-ENV NODE_ENV=${ENVIRONMENT}
+#Changed ENVIRONMENT to ENV to reference the ENV variable
+ENV NODE_ENV=${ENV}
 
 COPY package*.json ./
 
@@ -30,7 +35,8 @@ COPY package*.json ./
 RUN npm ci
 
 # Copy only the build artifacts from the previous stage
-COPY --from=bullder /app/dist ./dist
+#Corrected the stage name 'builder'
+COPY --from=builder /app/dist ./dist
 
 RUN ls
 # Expose the port your application listens on (if needed)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,4 +9,4 @@ services:
     environment:
       NODE_ENV: production
     ports:
-      - 8080:8080
+      - "8080:8080"


### PR DESCRIPTION
```json
FROM ${NODE_VERSION} AS builder
```
Referenced the NODE_VERSION variable by adding $ sign and putting the variable name in {}

```json
COPY . .
```
For this layer, it was only copying from the current directory on our local machine, but there was no directory specified in the Dockerfile. So I added . . to point to the workdir.

```json
RUN npm ci && \
    npm run build &&  \
    ls
```
Added && sign to depict that the commands should be run in succession; thus, install before build before list.

```json
FROM ${NODE_VERSION} AS deploy
```
Referenced the NODE_VERSION variable by adding $ sign and putting the variable name in {}

```json
ENV NODE_ENV=${ENV}
```
Previously, the NODE_ENV was assigned to a variable called ENVIRONMENT, which did not exist. So, I changed it to ENV to reference the variable ENV declared on line 3.

```json
COPY --from=builder /app/dist ./dist
```
This previous stage's name was **builder**; however, bullder was called instead. 